### PR TITLE
Support SwiftSyntax 0.50200.0

### DIFF
--- a/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/ParserViaSwiftSyntax.swift
+++ b/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/ParserViaSwiftSyntax.swift
@@ -69,7 +69,7 @@ public class ParserViaSwiftSyntax: SourceParsing {
         do {
             var results = [Entity]()
             let node = try SyntaxParser.parse(path)
-            node.walk(&treeVisitor)
+            treeVisitor.walk(node)
             let ret = treeVisitor.entities
             for ent in ret {
                 ent.filepath = path

--- a/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
@@ -27,7 +27,7 @@ extension SyntaxParser {
     }
 }
 
-extension Syntax {
+extension SyntaxProtocol {
     var offset: Int64 {
         return Int64(self.position.utf8Offset)
     }

--- a/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
@@ -146,40 +146,40 @@ extension MemberDeclListItemSyntax {
     }
     
     func transformToModel(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool)? {
-        if let varMember = self.decl as? VariableDeclSyntax {
+        if let varMember = self.decl.as(VariableDeclSyntax.self) {
             if validateMember(varMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(varMember.modifiers, encloserAcl, declType)
                 if let item = varMember.models(with: acl, declType: declType, overrides: metadata?.varTypes, processed: processed).first {
                     return (item, varMember.attributes?.trimmedDescription, false)
                 }
             }
-        } else if let funcMember = self.decl as? FunctionDeclSyntax {
+        } else if let funcMember = self.decl.as(FunctionDeclSyntax.self) {
             if validateMember(funcMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(funcMember.modifiers, encloserAcl, declType)
                 let item = funcMember.model(with: acl, declType: declType, processed: processed)
                 return (item, funcMember.attributes?.trimmedDescription, false)
             }
-        } else if let subscriptMember = self.decl as? SubscriptDeclSyntax {
+        } else if let subscriptMember = self.decl.as(SubscriptDeclSyntax.self) {
             if validateMember(subscriptMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(subscriptMember.modifiers, encloserAcl, declType)
                 let item = subscriptMember.model(with: acl, declType: declType, processed: processed)
                 return (item, subscriptMember.attributes?.trimmedDescription, false)
             }
-        } else if let initMember = self.decl as? InitializerDeclSyntax {
+        } else if let initMember = self.decl.as(InitializerDeclSyntax.self) {
             if validateInit(initMember, declType, processed: processed) {
                 let acl = memberAcl(initMember.modifiers, encloserAcl, declType)
                 let item = initMember.model(with: acl, declType: declType, processed: processed)
                 return (item, initMember.attributes?.trimmedDescription, true)
             }
-        } else if let patMember = self.decl as? AssociatedtypeDeclSyntax {
+        } else if let patMember = self.decl.as(AssociatedtypeDeclSyntax.self) {
             let acl = memberAcl(patMember.modifiers, encloserAcl, declType)
             let item = patMember.model(with: acl, declType: declType, overrides: metadata?.typeAliases, processed: processed)
             return (item, patMember.attributes?.trimmedDescription, false)
-        } else if let taMember = self.decl as? TypealiasDeclSyntax {
+        } else if let taMember = self.decl.as(TypealiasDeclSyntax.self) {
             let acl = memberAcl(taMember.modifiers, encloserAcl, declType)
             let item = taMember.model(with: acl, declType: declType, overrides: metadata?.typeAliases, processed: processed)
             return (item, taMember.attributes?.trimmedDescription, false)
-        } else if let ifMacroMember = self.decl as? IfConfigDeclSyntax {
+        } else if let ifMacroMember = self.decl.as(IfConfigDeclSyntax.self) {
             let (item, attr, initFlag) = ifMacroMember.model(with: encloserAcl, declType: declType, metadata: metadata, processed: processed)
             return (item, attr, initFlag)
         }
@@ -191,7 +191,7 @@ extension MemberDeclListItemSyntax {
 extension MemberDeclListSyntax {
     var hasBlankInit: Bool {
         for member in self {
-            if let varMember = member.decl as? VariableDeclSyntax {
+            if let varMember = member.decl.as(VariableDeclSyntax.self) {
                 for v in varMember.bindings {
                     if let name = v.pattern.firstToken?.text {
                         if name == String.hasBlankInit {
@@ -230,7 +230,7 @@ extension IfConfigDeclSyntax {
 
         var name = ""
         for cl in self.clauses {
-            if let desc = cl.condition?.description, let list = cl.elements as? MemberDeclListSyntax {
+            if let desc = cl.condition?.description, let list = cl.elements.as(MemberDeclListSyntax.self) {
                 name = desc
                 
                 for element in list {

--- a/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
@@ -573,7 +573,7 @@ final class EntityVisitor: SyntaxVisitor {
         imports = []
     }
     
-    func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         let metadata = node.annotationMetadata(with: annotation)
         if let ent = Entity.node(with: node, isPrivate: node.isPrivate, isFinal: false, metadata: metadata, processed: false) {
             entities.append(ent)
@@ -581,7 +581,7 @@ final class EntityVisitor: SyntaxVisitor {
         return .skipChildren
     }
     
-    func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         if node.name.hasSuffix("Mock") {
             // this mock class node must be public else wouldn't have compiled before
             if let ent = Entity.node(with: node, isPrivate: node.isPrivate, isFinal: false, metadata: nil, processed: true) {
@@ -596,7 +596,7 @@ final class EntityVisitor: SyntaxVisitor {
         return .skipChildren
     }
     
-    func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
         if let ret = node.path.firstToken?.text {
             let desc = node.importTok.text + " " + ret
             imports.append(desc)


### PR DESCRIPTION
<!---
These changes are needed to compile with SwiftSyntax 0.50200.0 and Xcode 11.4.

[SwiftSyntax Changelog](https://github.com/apple/swift-syntax/blob/master/Changelog.md)

c2c4685
> The walk method on syntax nodes has been removed.
> Instead, use the walk method on the SyntaxVisitor.
>
>     // Before 
>     tree.walk(&visitor)
>     // Now
>     visitor.walk(tree)

d036a53

> The protocols ExprSyntax, DeclSyntax, Syntax etc. have been removed

> For passing values of these types around, use the new type erasers ExprSyntax, DeclSyntax, Syntax etc. instead. To add computed properties or functions to all expression nodes, write an extension on ExprSyntaxProtocol. To add methods to all syntax nodes, extend SyntaxProtcol.

a554faf

> Downcasting can no longer be performed using the as operator. For downcasting use the as(_: SyntaxProtocol) method on any type eraser.

ab6eec5
> SyntaxVisitor and SyntaxAnyVisitor are a class and no longer a protocol.
> Any structs conforming to the above protocols need to become classes. Implementing methods need to be marked override and, if necessary, any mutating keywords need to be removed.
--->